### PR TITLE
Make the hostname configurable and a bug fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM nginx:alpine
 
 ENV HTPASSWD='foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.' \
-    FORWARD_PORT=80
+    FORWARD_PORT=80 \
+    FORWARD_HOST=web
 
 WORKDIR /opt
 

--- a/auth.conf
+++ b/auth.conf
@@ -1,11 +1,11 @@
 server {
  listen 80 default_server;
- 
+
  location / {
      auth_basic              "Restricted";
      auth_basic_user_file    auth.htpasswd;
 
-     proxy_pass                          http://web:${FORWARD_PORT};
+     proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};
      proxy_read_timeout                  900;
  }
 }

--- a/launch.sh
+++ b/launch.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+rm /etc/nginx/conf.d/default.conf || :
 envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
 envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd
 


### PR DESCRIPTION
The reason to make the hostname configurable is that the new `docker service` system does not support yet network aliases.