### PR TITLE
add support for optional custom dns resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM nginx:alpine
 
 ENV HTPASSWD='foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.' \
     FORWARD_PORT=80 \
-    FORWARD_HOST=web
+    FORWARD_HOST=web \
+    DNS_RESOLVER=
 
 WORKDIR /opt
 

--- a/launch.sh
+++ b/launch.sh
@@ -4,4 +4,8 @@ rm /etc/nginx/conf.d/default.conf || :
 envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
 envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd
 
+if [ -n "${DNS_RESOLVER}" ]; then
+  echo "resolver ${DNS_RESOLVER};" >> /etc/nginx/conf.d/auth.conf
+fi
+
 nginx -g "daemon off;"


### PR DESCRIPTION
in cases of dynamic envinronments where containers move around
and respwan due to health checks, the IP of the forwarded host
might change nand should be resolved in case it's not found
this change introduces an optional dns resolver if it's needed
more info at https://tenzer.dk/nginx-with-dynamic-upstreams/