### PR TITLE
adding docker healthcheck and an unauthenticated port for external healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /opt
 
 RUN apk add --no-cache gettext
 
-COPY auth.conf auth.htpasswd launch.sh ./
+COPY auth.conf healthcheck.conf auth.htpasswd launch.sh ./
+
+HEALTHCHECK CMD wget -q http://localhost:80/ || exit 1
 
 CMD ["./launch.sh"]

--- a/auth.conf
+++ b/auth.conf
@@ -1,11 +1,14 @@
 server {
- listen 80 default_server;
+  listen 80 default_server;
 
- location / {
-     auth_basic              "Restricted";
-     auth_basic_user_file    auth.htpasswd;
+  location / {
+    satisfy  any;
+    allow 127.0.0.1;
+    deny   all;
+    auth_basic              "Restricted";
+    auth_basic_user_file    auth.htpasswd;
 
-     proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};
-     proxy_read_timeout                  900;
- }
+    proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};
+    proxy_read_timeout                  900;
+  }
 }

--- a/healthcheck.conf
+++ b/healthcheck.conf
@@ -1,0 +1,8 @@
+server {
+  listen 9999 default_server;
+
+  location / {
+    proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};
+    proxy_read_timeout                  900;
+  }
+}

--- a/launch.sh
+++ b/launch.sh
@@ -2,6 +2,7 @@
 
 rm /etc/nginx/conf.d/default.conf || :
 envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
+envsubst < healthcheck.conf > /etc/nginx/conf.d/healthcheck.conf
 envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd
 
 nginx -g "daemon off;"


### PR DESCRIPTION
starting docker v1.12 there's an option for an internal healthcheck
this commit allows an unauthenticated requests from localhost and
adds an additional server with port 9999 for orchestrated healthchecks
like rancher or k8s, this port should not be exposed to untrusted networks