### PR TITLE
Make the realm configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM nginx:alpine
 
 ENV HTPASSWD='foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.' \
     FORWARD_PORT=80 \
-    FORWARD_HOST=web
+    FORWARD_HOST=web \
+    REALM="Restricted"
 
 WORKDIR /opt
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker run -d \
 ## Configuration
 - `HTPASSWD` (default: `foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.`): Will be written to the .htpasswd file on launch (non-persistent)
 - `FORWARD_PORT` (default: `80`): Port of the **source** container that should be forwarded
+- `REALM` (default: `"Restricted"`): Realm authentication parameter, this is also the message that will appear in the password dialog. The special value `off` disables the authentication.
 > The container does not need any volumes to be mounted! Nonetheless you will find all interesting files at `/etc/nginx/*`.
 
 ## Multiple Users

--- a/auth.conf
+++ b/auth.conf
@@ -2,7 +2,7 @@ server {
  listen 80 default_server;
 
  location / {
-     auth_basic              "Restricted";
+     auth_basic              "${REALM}";
      auth_basic_user_file    auth.htpasswd;
 
      proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};

--- a/auth.conf
+++ b/auth.conf
@@ -1,11 +1,11 @@
 server {
- listen 80 default_server;
+    listen 80 default_server;
 
- location / {
-     auth_basic              "${REALM}";
-     auth_basic_user_file    auth.htpasswd;
+    location / {
+        auth_basic              "${REALM}";
+        auth_basic_user_file    auth.htpasswd;
 
-     proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};
-     proxy_read_timeout                  900;
- }
+        proxy_pass              http://${FORWARD_HOST}:${FORWARD_PORT};
+        proxy_read_timeout      900;
+    }
 }


### PR DESCRIPTION
This pull request lets users set custom messages in the username/password pop-up.

It also provides a more elegant way to tackle @fhuitelec issue (_cf._ [pull request #3](https://github.com/beevelop/docker-nginx-basic-auth/pull/3)), as authentication can be turned off using special value `off` for a realm.