### PR TITLE
Allow configuration of bind port, and update documentation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:alpine
 
 ENV HTPASSWD='foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.' \
+    PORT=80 \
     FORWARD_PORT=80 \
     FORWARD_HOST=web
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ docker run -d \
 
 ## Configuration
 - `HTPASSWD` (default: `foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.`): Will be written to the .htpasswd file on launch (non-persistent)
-- `FORWARD_PORT` (default: `80`): Port of the **source** container that should be forwarded
+- `PORT` (default: `80`): Port that the nginx should bind to.
+- `FORWARD_HOST` (default: `web`): Host of the **source** container that should be forwarded.
+- `FORWARD_PORT` (default: `80`): Port of the **source** container that should be forwarded.
 > The container does not need any volumes to be mounted! Nonetheless you will find all interesting files at `/etc/nginx/*`.
 
 ## Multiple Users

--- a/auth.conf
+++ b/auth.conf
@@ -1,5 +1,5 @@
 server {
- listen 80 default_server;
+ listen ${PORT} default_server;
 
  location / {
      auth_basic              "Restricted";


### PR DESCRIPTION
This adds support for which port you bind to. This was required for me to properly forward a stock nginx container on Kubernetes.

Aside from adding more configuration options, I don't see a downside of this addition.

I also updated the documentation for this change and `FORWARD_HOST`.