### PR TITLE
Raw credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV HTPASSWD='foo:$apr1$odHl5EJN$KbxMfo86Qdve2FH4owePn.' \
 
 WORKDIR /opt
 
-RUN apk add --no-cache gettext
+RUN apk add --no-cache gettext apache2-utils
 
 COPY auth.conf auth.htpasswd launch.sh ./
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ docker run -d --link web:web --name auth \
 ```
 results in 2 users (`foo:bar` and `test:test`).
 
+## Raw Credentials
+If passing the contents of the HTPASSWD file is not convenient for you (because
+you need to perform additional step of generating it via `htpasswd -nb foo
+bar`), you can pass the credentials in a raw form and the contents of HTPASSWD
+variable will be generated for you. The `RAW_CREDENTIALS=1` must be set to
+enable this feature.
+
+```
+docker run -d --link web:web --name auth \
+           -e HTPASSWD=$'foo:bar\ntest:test' \
+           -e RAW_CREDENTIALS=1 \
+           beevelop/nginx-basic-auth
+```
+
 ## Troubleshooting
 ```
 nginx: [emerg] host not found in upstream "web" in /etc/nginx/conf.d/auth.conf:80

--- a/launch.sh
+++ b/launch.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+if [ "$RAW_CREDENTIALS" = 1 ]; then
+  HTPASSWD=$(
+    for line in $(echo $HTPASSWD); do
+      USERNAME="$(echo "$line" | cut -d':' -f1)"
+      PASSWORD="$(echo "$line" | cut -d':' -f2)"
+      htpasswd -nb "$USERNAME" "$PASSWORD" | head -n1
+    done
+  )
+fi
+
 rm /etc/nginx/conf.d/default.conf || :
 envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
 envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd


### PR DESCRIPTION
Hello, it is sometimes convenient to pass the credentials in a non-hashed form, when creating the basic auth proxy. I have added the feature... The drawback is that the `apache2-utils` need to be installed but it is only a ~200KB package.