### PR TITLE
docker-cloud.yml: add Docker stack example

### DIFF
--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -1,0 +1,27 @@
+version: '3.1'
+
+volumes:
+  web-data:
+
+services:
+
+  web:
+    image: 'nginx'
+    ## instead of an exposed port use FORWARD_PORT below
+    # ports:
+    #   - '80:80'
+    volumes:
+      - web-data:/usr/share/nginx/html:ro
+  
+  auth:
+    image: 'beevelop/nginx-basic-auth'
+    links:
+      - 'web'
+    ports:
+      - '8080:80'
+    environment:
+      - PORT=80
+      - FORWARD_HOST=web
+      - FORWARD_PORT=80
+      ## escape $ with $$ in Docker yml due to variable expansion
+      - HTPASSWD=foo:$$apr1$$odHl5EJN$$KbxMfo86Qdve2FH4owePn.

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,5 +1,14 @@
 version: '3.1'
 
+# run with docker-compose:
+#
+#     docker-compose -f docker-stack.yml up
+
+# run with docker swarm:
+#
+#     docker swarm init
+#     docker stack deploy --compose-file docker-stack.yml authdemo
+
 volumes:
   web-data:
 
@@ -7,7 +16,7 @@ services:
 
   web:
     image: 'nginx'
-    ## instead of an exposed port use FORWARD_PORT below
+    ## instead of an exposed port, use FORWARD_PORT in auth, below
     # ports:
     #   - '80:80'
     volumes:
@@ -15,8 +24,6 @@ services:
   
   auth:
     image: 'beevelop/nginx-basic-auth'
-    links:
-      - 'web'
     ports:
       - '8080:80'
     environment:
@@ -24,4 +31,5 @@ services:
       - FORWARD_HOST=web
       - FORWARD_PORT=80
       ## escape $ with $$ in Docker yml due to variable expansion
+      ## example user/pass generated with htpasswd is foo:bar
       - HTPASSWD=foo:$$apr1$$odHl5EJN$$KbxMfo86Qdve2FH4owePn.


### PR DESCRIPTION
Demonstrate a minimal stack with a generic volume, web host, and proxy.

Demonstrates no exposed port on the source server and the need to escape $ values in the HTPASSWD.

closes #15 
