### PR TITLE
fix Dockerfile and entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ RUN apk add --no-cache gettext
 
 COPY auth.conf auth.htpasswd launch.sh ./
 
-CMD ["./launch.sh"]
+ENTRYPOINT ["./launch.sh"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/launch.sh
+++ b/launch.sh
@@ -4,4 +4,4 @@ rm /etc/nginx/conf.d/default.conf || :
 envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
 envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd
 
-nginx -g "daemon off;"
+exec "$@"


### PR DESCRIPTION
## In entrypoint script `launch.sh`
By using `exec "$@"` at the end, `nginx` will be `PID 1` inside the docker container, instead of `/bin/sh`. It also allows kill signals to reach `nginx` directly from the docker host. 

## In Dockerfile
By using `ENTRYPOINT ["./launch.sh"]` it makes it clear that `launch.sh` is the entrypoint, especially when using `docker inspect <image>`.
By using `CMD ["nginx", "-g", "daemon off;"]`, it allows the users to override the CMD if they prefer.