### PR TITLE
Fix signal propagation by replacing init shell with nginx

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -4,4 +4,4 @@ rm /etc/nginx/conf.d/default.conf || :
 envsubst < auth.conf > /etc/nginx/conf.d/auth.conf
 envsubst < auth.htpasswd > /etc/nginx/auth.htpasswd
 
-nginx -g "daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Signals like SIGINT are sent to the init process. Currently these signals are not propagated to the nginx process, inhibiting a graceful shutdown. This PR fixes that by replacing the init shell with the nginx process, so that signals are sent to the nginx process instead.