### PR TITLE
Forward original Host header to upstream

### DIFF
--- a/auth.conf
+++ b/auth.conf
@@ -7,5 +7,8 @@ server {
 
      proxy_pass                          http://${FORWARD_HOST}:${FORWARD_PORT};
      proxy_read_timeout                  900;
+     # Forward Host header
+     # ${no_value} is a hack to bypass envsubst substitution
+     proxy_set_header Host      $${no_value}host;
  }
 }


### PR DESCRIPTION
Hello

The Host header is from now not forwarded to upstream server.

This commit use a "hack" in order to prevent the $host var to be substitute by envsubst and allow nginx to send host header.

Feel free to comment.

Regards